### PR TITLE
Add merge PDFs plus tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ formalpdf fill <input.pdf> <input.fdf> <output.pdf>
 ### Get All `Widget` Objects in a PDF
 
 ```py
-from formalpdf import Document
+import formalpdf
 
-doc = Document("/path/to/your.pdf")
+doc = formalpdf.open("path/to/document.pdf") 
 
 for page in doc:
     widgets = page.widgets()
@@ -113,9 +113,9 @@ You can use this to do lower-level operations that aren't yet supported by `form
 For instance, if you want to render the first page of the document (currently an unsupported option):
 
 ```py
-from formalpdf import Document
+import formalpdf
 
-doc = Document("/path/to/your.pdf")
+doc = formalpdf.open("path/to/document.pdf")
 
 pdfium_doc = doc.document
 bmp = pdfium_doc[0].render(scale=scale)

--- a/formalpdf/__init__.py
+++ b/formalpdf/__init__.py
@@ -1,1 +1,1 @@
-from .widget import Document, Page, Widget, Rect
+from .widget import Document, Page, Widget, Rect, open

--- a/formalpdf/widget.py
+++ b/formalpdf/widget.py
@@ -11,10 +11,18 @@ import pypdfium2 as pdfium
 import ctypes
 
 
+def open(path: str | Path | None = None) -> Document:
+    return Document(path)
+
+
+
 class Document:
-    def __init__(self, path: str):
-        self.document = pdfium.PdfDocument(path)
-        self._init_formenv()
+    def __init__(self, path: str | Path | None = None):
+        if path:
+            self.document = pdfium.PdfDocument(path)
+            self._init_formenv()
+        else:
+            self.document = pdfium.PdfDocument.new()
 
     def _init_formenv(self):
         if self.form_type is not None:

--- a/formalpdf/widget.py
+++ b/formalpdf/widget.py
@@ -77,6 +77,30 @@ class Document:
         """
         return self.document.save(dest, version=version, flags=flags)
 
+    def insert_pdf(
+        self,
+        other: Document,
+        *,
+        index: int | None = None,
+        from_page: int | None = None,
+        to_page: int | None = None
+    ) -> None:
+        """
+        Insert pages from one PDF into another PDF, optionally at a specified index. If index is None,
+        the pages will be appended to the PDF.
+        """
+        if not from_page:
+            from_page = 0
+        if not to_page:
+            to_page = len(other)
+
+        page_range = list(range(from_page, to_page))
+
+        self.document.import_pages(
+            other.document,
+            pages=page_range,
+            index=index
+        )
     
 class Page:
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def output_dir() -> Path:
+    """Create a temporary tests/output directory for generated PDFs and clean it up after the session."""
+    base = Path(__file__).parent / "output"
+    # Ensure a clean directory for this test session
+    if base.exists():
+        shutil.rmtree(base, ignore_errors=True)
+    base.mkdir(parents=True, exist_ok=True)
+    try:
+        yield base
+    finally:
+        # Remove the directory and all its contents
+        shutil.rmtree(base, ignore_errors=True)
+

--- a/tests/test_form_read.py
+++ b/tests/test_form_read.py
@@ -1,6 +1,6 @@
 import pytest
+import formalpdf
 
-from formalpdf import Document
 from pathlib import Path
 
 
@@ -13,7 +13,7 @@ def _all_pdf_paths() -> list[Path]:
 
 @pytest.mark.parametrize("pdf_path", _all_pdf_paths(), ids=lambda p: p.name)
 def test_open_and_list_widgets(pdf_path: Path):
-    doc = Document(str(pdf_path))
+    doc = formalpdf.open(pdf_path) 
 
     total = 0
     for page in doc:

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1,0 +1,105 @@
+from pathlib import Path
+
+import pytest
+
+import formalpdf
+
+
+DATA_DIR = Path(__file__).parent / "data"
+
+
+def _pdf(path: str) -> Path:
+    return DATA_DIR / path
+
+
+def _count_widgets(doc: formalpdf.Document) -> list[int]:
+    return [len(page.widgets()) for page in doc]
+
+
+def test_merge_complete_document(output_dir: Path):
+    dest = formalpdf.open(_pdf("text_inputs.pdf"))
+    src = formalpdf.open(_pdf("checkbox.pdf"))
+
+    before = len(dest)
+    added = len(src)
+
+    dest.insert_pdf(src)
+
+    assert len(dest) == before + added
+
+    out = output_dir / "merge_complete.pdf"
+    dest.save(str(out))
+    assert out.exists() and out.stat().st_size > 0
+
+
+def test_merge_range(output_dir: Path):
+    dest = formalpdf.open(_pdf("text_inputs.pdf"))
+    src = formalpdf.open(_pdf("checkbox.pdf"))
+
+    before = len(dest)
+    # take at most first 2 pages from src
+    from_page = 0
+    to_page = min(2, len(src))
+    expected_added = max(0, to_page - from_page)
+
+    dest.insert_pdf(src, from_page=from_page, to_page=to_page)
+    assert len(dest) == before + expected_added
+
+    out = output_dir / "merge_range.pdf"
+    dest.save(str(out))
+    assert out.exists() and out.stat().st_size > 0
+
+
+def test_merge_at_index(output_dir: Path):
+    dest = formalpdf.open(_pdf("text_inputs.pdf"))
+    src = formalpdf.open(_pdf("checkbox.pdf"))
+
+    # capture widget counts of src to validate placement
+    src_widget_counts = _count_widgets(src)
+    assert src_widget_counts, "Source document unexpectedly has zero pages"
+
+    # insert at the beginning
+    dest.insert_pdf(src, index=0)
+
+    # After insertion, the first len(src) pages should correspond to src pages
+    for i, expected in enumerate(src_widget_counts):
+        assert len(dest[i].widgets()) == expected
+
+    out = output_dir / "merge_at_index.pdf"
+    dest.save(str(out))
+    assert out.exists() and out.stat().st_size > 0
+
+
+def test_widgets_maintained_during_merge(output_dir: Path):
+    dest = formalpdf.open(_pdf("text_inputs.pdf"))
+    src = formalpdf.open(_pdf("checkbox.pdf"))
+
+    src_widget_counts = _count_widgets(src)
+    # Sanity: ensure src actually has widgets to make this meaningful
+    assert any(c > 0 for c in src_widget_counts)
+
+    dest.insert_pdf(src, index=0)
+
+    # Compare per-page widget counts for the inserted range
+    for i, expected in enumerate(src_widget_counts):
+        assert len(dest[i].widgets()) == expected
+
+    out = output_dir / "merge_widgets_preserved.pdf"
+    dest.save(str(out))
+    assert out.exists() and out.stat().st_size > 0
+
+
+def test_merge_document_with_itself(output_dir: Path):
+    # Open the same file twice to simulate merging a document with itself
+    original = formalpdf.open(_pdf("text_inputs.pdf"))
+    dest = formalpdf.open(_pdf("text_inputs.pdf"))
+
+    before = len(dest)
+    added = len(original)
+
+    dest.insert_pdf(original)
+    assert len(dest) == before + added
+
+    out = output_dir / "merge_self.pdf"
+    dest.save(str(out))
+    assert out.exists() and out.stat().st_size > 0


### PR DESCRIPTION
You can now merge PDF's roughly following `pymupdf`'s insert_pdf format (`from_page`, `to_page`). Still needs cleanup, but it does preserve annotations in all cases right now.